### PR TITLE
Fix Import Errors in model_setup.py, dataset_generator.py, and utils.py

### DIFF
--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -3,6 +3,7 @@ from typing import List
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from tqdm import tqdm
 from utils import read_file, preprocess_text
+from config import CONFIG
 
 def load_input_data(input_folder: str) -> List[str]:
     texts = []

--- a/src/dataset_generator.py
+++ b/src/dataset_generator.py
@@ -4,6 +4,7 @@ from tqdm import tqdm
 import torch
 from torch.utils.data import DataLoader, Dataset
 from utils import generate_gpt2_output, generate_t5_output, extract_keywords
+from config import CONFIG
 
 class TextDataset(Dataset):
     def __init__(self, texts, instructions):

--- a/src/model_setup.py
+++ b/src/model_setup.py
@@ -1,5 +1,7 @@
+import torch
 from transformers import GPT2LMHeadModel, GPT2Tokenizer, T5ForConditionalGeneration, T5Tokenizer, pipeline
 from sentence_transformers import SentenceTransformer
+from config import CONFIG
 
 def setup_models():
     models = {}

--- a/src/utils.py
+++ b/src/utils.py
@@ -13,7 +13,7 @@ from sentence_transformers import SentenceTransformer
 nltk.download('stopwords', quiet=True)
 
 # Import CONFIG if it's defined in a separate file
-# from config import CONFIG
+from config import CONFIG
 
 def read_text_file(file_path: str) -> str:
     """Read content from a text file."""


### PR DESCRIPTION
[FIXED] 
1. `torch` was not imported in model_setup.py file, 
2. `from config import CONFIG` was not called in dataset_generator.py, model_setup.py and utils.py file which were causing 'No Module found errors".  

[FIXED]