### PR TITLE
Support Markdown (.md) files in data loading and processing

### DIFF
--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -26,7 +26,7 @@ def load_input_data(input_folder: str) -> List[str]:
             futures = []
             for root, _, files in os.walk(input_folder):
                 for file in files:
-                    if file.lower().endswith(('.txt', '.pdf', '.docx')):
+                    if file.lower().endswith(('.txt', '.md', '.pdf', '.docx')):
                         file_path = os.path.join(root, file)
                         futures.append(executor.submit(process_file, file_path))
             

--- a/src/utils.py
+++ b/src/utils.py
@@ -47,7 +47,7 @@ def read_docx_file(file_path: str) -> str:
 def read_file(file_path: str) -> str:
     """Read content from a file based on its extension."""
     _, ext = os.path.splitext(file_path.lower())
-    if ext == '.txt':
+    if (ext == '.txt') or (ext == '.md'):
         return read_text_file(file_path)
     elif ext == '.pdf':
         return read_pdf_file(file_path)


### PR DESCRIPTION
This commit extends the dataset generator so that Markdown files (`*.md`) are treated like plain text during loading and processing.  
In `data_loader.py`, the file‑extension filter now includes `.md` alongside `.txt`, `.pdf`, and `.docx`.  
The `read_file` helper in `utils.py` was updated to read `.md` files using the same routine as for `.txt` files, enabling Markdown content to be parsed into paragraphs.  
These changes allow the loader to discover, read, and preprocess Markdown documents without altering any import logic or test behavior.  
Overall, the update broadens supported input types while keeping existing functionality unchanged.