### PR TITLE
Improve prompt quality, fix bugs, and add CLI path arguments

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -14,6 +14,10 @@ CONFIG = {
         'sentiment': 'distilbert-base-uncased-finetuned-sst-2-english',
         'sentence': 'all-MiniLM-L6-v2'
     },
+    # Text chunking parameters
+    'chunk_size': 1500,       # target max characters per chunk
+    'chunk_overlap': 200,     # overlap between consecutive chunks
+
     # Text processing parameters
     'keyword_count': 5,
     
@@ -29,6 +33,7 @@ CONFIG = {
     'min_word_count': 10,
     'min_output_length': 50,
     'min_similarity_threshold': 0.3,
+    'dedup_threshold': 0.95,  # cosine similarity above which outputs are considered duplicates
     'min_explanation_word_count': 30,
     'min_learning_path_steps': 3,
     'min_quiz_options': 4,

--- a/src/config.py
+++ b/src/config.py
@@ -30,21 +30,101 @@ CONFIG = {
     'min_output_length': 50,
     'min_similarity_threshold': 0.3,
     'min_explanation_word_count': 30,
-    'min_learning_path_stepspath_steps': 3,
+    'min_learning_path_steps': 3,
     'min_quiz_options': 4,
     'difficulty_keywords': ['easy', 'medium', 'difficult', 'challenging'],
     
     # Instruction types for dataset generation
     'instruction_types': [
-        ("concept_explanation", "Explain the following concept in simple terms:"),
-        ("generate_question", "Generate a thought-provoking question about this concept:"),
-        ("provide_example", "Provide a real-world example that illustrates this concept:"),
-        ("learning_path", "Suggest a learning path to master this concept, including prerequisite topics and follow-up areas:"),
-        ("misconception", "Identify and correct a common misconception about this concept:"),
-        ("analogy", "Create an analogy to help understand this concept:"),
-        ("quiz_generation", "Generate a multiple-choice quiz question about this concept, including the correct answer and three plausible distractors:"),
-        ("concept_relation", "Explain how this concept relates to another relevant concept in the field:"),
-        ("application", "Describe a practical application or use case for this concept:"),
-        ("difficulty_assessment", "Assess the difficulty level of this concept and explain why it might be challenging for some students:")
+        ("concept_explanation",
+         "Explain the following concept in simple terms.\n\n"
+         "Example:\n"
+         "Concept: recursion\n"
+         "Explanation: Recursion is when a function calls itself to solve a smaller version of the same problem. "
+         "Imagine looking up a word in a dictionary and finding its definition uses another word you don't know — "
+         "so you look that one up too. You keep going until you hit a word you already understand.\n\n"
+         "Now explain:"),
+
+        ("generate_question",
+         "Generate a thought-provoking question about the following concept.\n\n"
+         "Example:\n"
+         "Concept: natural selection\n"
+         "Question: If natural selection favors survival of the fittest, why do cooperative behaviors like altruism persist in many species?\n\n"
+         "Now generate a question about:"),
+
+        ("provide_example",
+         "Provide a concrete, real-world example that illustrates the following concept.\n\n"
+         "Example:\n"
+         "Concept: opportunity cost\n"
+         "Example: When a student spends Saturday studying for an exam instead of working a part-time shift, "
+         "the opportunity cost is the wages they gave up — not just the time itself.\n\n"
+         "Now provide an example for:"),
+
+        ("learning_path",
+         "Suggest a step-by-step learning path to master the following concept, listing prerequisite topics first and follow-up areas at the end.\n\n"
+         "Example:\n"
+         "Concept: machine learning\n"
+         "Learning path:\n"
+         "1. Prerequisites: Linear algebra, probability and statistics, Python programming\n"
+         "2. Core topics: Supervised learning, gradient descent, model evaluation\n"
+         "3. Intermediate: Neural networks, regularization, hyperparameter tuning\n"
+         "4. Advanced follow-up: Deep learning, reinforcement learning, MLOps\n\n"
+         "Now suggest a learning path for:"),
+
+        ("misconception",
+         "Identify a common misconception about the following concept and explain why it is wrong.\n\n"
+         "Example:\n"
+         "Concept: evolution\n"
+         "Misconception: Many people think evolution means organisms consciously adapt to their environment.\n"
+         "Correction: Evolution has no intent or direction. Traits that improve survival are passed on through reproduction over many generations — no individual organism changes its genes by trying.\n\n"
+         "Now identify a misconception about:"),
+
+        ("analogy",
+         "Create a clear analogy that helps someone understand the following concept by comparing it to something familiar.\n\n"
+         "Example:\n"
+         "Concept: computer RAM\n"
+         "Analogy: RAM is like your desk — it's the workspace where you keep everything you're actively using. "
+         "Your hard drive is like a filing cabinet: much larger storage, but you have to walk over and retrieve things before you can work with them.\n\n"
+         "Now create an analogy for:"),
+
+        ("quiz_generation",
+         "Generate a multiple-choice quiz question about the following concept. "
+         "Include one correct answer and three plausible but incorrect distractors. Mark the correct answer.\n\n"
+         "Example:\n"
+         "Concept: photosynthesis\n"
+         "Question: What is the primary source of energy that drives photosynthesis?\n"
+         "A) Water\n"
+         "B) Carbon dioxide\n"
+         "C) Sunlight [CORRECT]\n"
+         "D) Oxygen\n\n"
+         "Now generate a quiz question about:"),
+
+        ("concept_relation",
+         "Explain how the following concept relates to another relevant concept in the same field.\n\n"
+         "Example:\n"
+         "Concept 1: supply\n"
+         "Concept 2: demand\n"
+         "Relation: Supply and demand are the two forces that together determine market price. "
+         "When demand rises but supply stays the same, prices increase. When supply outpaces demand, prices fall. "
+         "They act like two sides of a scale constantly seeking equilibrium.\n\n"
+         "Now explain how this concept relates to another:"),
+
+        ("application",
+         "Describe a specific, practical application or real-world use case for the following concept.\n\n"
+         "Example:\n"
+         "Concept: Fourier transform\n"
+         "Application: Audio engineers use Fourier transforms to break a sound recording into its individual frequency components. "
+         "This allows them to isolate and boost specific frequencies (like bass) or remove unwanted noise from a recording.\n\n"
+         "Now describe an application of:"),
+
+        ("difficulty_assessment",
+         "Assess the difficulty level of the following concept (easy / intermediate / advanced) and explain the specific reasons why learners find it challenging.\n\n"
+         "Example:\n"
+         "Concept: dynamic programming\n"
+         "Difficulty: Advanced\n"
+         "Reasons: Dynamic programming is hard for three reasons: (1) recognizing which problems have overlapping subproblems requires pattern-matching experience, "
+         "(2) formulating the recurrence relation demands abstract thinking, and "
+         "(3) translating the recurrence into correct bottom-up or top-down code requires careful implementation.\n\n"
+         "Now assess the difficulty of:")
     ]
 }

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -2,39 +2,41 @@ import os
 from typing import List
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from tqdm import tqdm
-from utils import read_file, preprocess_text
+from utils import read_file, chunk_text
 from config import CONFIG
 
+SUPPORTED_EXTENSIONS = ('.txt', '.pdf', '.docx', '.md', '.csv', '.json', '.jsonl')
+
 def load_input_data(input_folder: str) -> List[str]:
-    texts = []
-    total_files = sum(len(files) for _, _, files in os.walk(input_folder))
-    print(f"Found {total_files} files to process")
-    
+    all_files = [
+        os.path.join(root, file)
+        for root, _, files in os.walk(input_folder)
+        for file in files
+        if file.lower().endswith(SUPPORTED_EXTENSIONS)
+    ]
+    print(f"Found {len(all_files)} supported files to process")
+
     def process_file(file_path):
         try:
-            print(f"Processing file: {file_path}")
             text = read_file(file_path)
-            paragraphs = [preprocess_text(para) for para in text.split('\n\n') if para.strip()]
-            print(f"Extracted {len(paragraphs)} paragraphs from {file_path}")
-            return paragraphs
+            chunks = chunk_text(
+                text,
+                chunk_size=CONFIG.get('chunk_size', 1500),
+                overlap=CONFIG.get('chunk_overlap', 200),
+            )
+            print(f"  {os.path.basename(file_path)}: {len(chunks)} chunks")
+            return chunks
         except Exception as e:
-            print(f"Error reading file {file_path}: {e}")
+            print(f"Error reading {file_path}: {e}")
             return []
 
-    with tqdm(total=total_files, desc="Loading input files", unit="file") as pbar:
+    texts = []
+    with tqdm(total=len(all_files), desc="Loading input files", unit="file") as pbar:
         with ThreadPoolExecutor(max_workers=CONFIG['max_workers']) as executor:
-            futures = []
-            for root, _, files in os.walk(input_folder):
-                for file in files:
-                    if file.lower().endswith(('.txt', '.pdf', '.docx')):
-                        file_path = os.path.join(root, file)
-                        futures.append(executor.submit(process_file, file_path))
-            
+            futures = {executor.submit(process_file, fp): fp for fp in all_files}
             for future in as_completed(futures):
-                result = future.result()
-                texts.extend(result)
-                print(f"Added {len(result)} paragraphs to texts")
+                texts.extend(future.result())
                 pbar.update(1)
 
-    print(f"Total paragraphs loaded: {len(texts)}")
+    print(f"Total chunks loaded: {len(texts)}")
     return texts

--- a/src/dataset_generator.py
+++ b/src/dataset_generator.py
@@ -22,12 +22,47 @@ class TextDataset(Dataset):
 
 def generate_dataset(input_texts: List[str], models: Dict) -> List[Dict[str, Any]]:
     instructions = [
-        ("summarize", "Provide a concise one-sentence summary of the following text:"),
-        ("keyword", "Extract 3-5 main keywords or key phrases from the following text:"),
-        ("title", "Generate a short, engaging title for the following text:"),
-        ("sentiment", "Analyze the sentiment of the following text. Classify it as positive, negative, or neutral, and briefly explain your reasoning:"),
-        ("question", "Generate a thought-provoking question based on the main idea of the following text:"),
-        ("paraphrase", "Rewrite the following text in your own words, maintaining its core meaning:"),
+        ("summarize",
+         "Provide a concise one-sentence summary of the following text.\n\n"
+         "Example:\n"
+         "Text: The mitochondria generate energy for the cell by converting nutrients into ATP through a process called cellular respiration. This process requires oxygen and produces carbon dioxide as a byproduct.\n"
+         "Summary: Mitochondria produce ATP — the cell's energy currency — by converting nutrients through oxygen-dependent cellular respiration.\n\n"
+         "Now summarize:"),
+
+        ("keyword",
+         "Extract 3-5 main keywords or key phrases from the following text. Return them as a comma-separated list.\n\n"
+         "Example:\n"
+         "Text: Deep learning models use multiple layers of artificial neurons to learn hierarchical representations of data, enabling breakthroughs in image recognition and natural language processing.\n"
+         "Keywords: deep learning, artificial neurons, hierarchical representations, image recognition, natural language processing\n\n"
+         "Now extract keywords from:"),
+
+        ("title",
+         "Generate a short, engaging title (5-8 words) for the following text.\n\n"
+         "Example:\n"
+         "Text: Studies show that regular aerobic exercise improves memory, reduces anxiety, and may slow cognitive decline in older adults by promoting neuroplasticity and increasing blood flow to the brain.\n"
+         "Title: How Exercise Rewires and Protects the Brain\n\n"
+         "Now generate a title for:"),
+
+        ("sentiment",
+         "Analyze the sentiment of the following text. Classify it as Positive, Negative, or Neutral, then briefly explain your reasoning in one sentence.\n\n"
+         "Example:\n"
+         "Text: The product arrived two days late and the packaging was damaged, though the item itself worked fine.\n"
+         "Sentiment: Negative. Despite the product functioning correctly, the late delivery and damaged packaging create an overall negative customer experience.\n\n"
+         "Now analyze the sentiment of:"),
+
+        ("question",
+         "Generate one thought-provoking question based on the main idea of the following text. The question should end with a question mark.\n\n"
+         "Example:\n"
+         "Text: Antibiotic resistance is accelerating globally as bacteria evolve faster than new drugs are developed, threatening to make common infections untreatable.\n"
+         "Question: If antibiotic resistance continues to outpace drug development, how should healthcare systems prioritize access to the remaining effective antibiotics?\n\n"
+         "Now generate a question based on:"),
+
+        ("paraphrase",
+         "Rewrite the following text in different words while preserving its core meaning. Do not add new information.\n\n"
+         "Example:\n"
+         "Text: The stock market experienced significant volatility last quarter due to rising interest rates and investor uncertainty about inflation.\n"
+         "Paraphrase: Last quarter's stock market saw sharp fluctuations driven by higher interest rates and widespread investor concern over inflation levels.\n\n"
+         "Now paraphrase:"),
     ]
 
     dataset = TextDataset(input_texts, instructions)
@@ -58,13 +93,13 @@ def generate_batch(models: Dict, texts: List[str], instruction_types: List[str],
             keywords = extract_keywords(text)
             output = ", ".join(keywords)
         elif instruction_type == "sentiment":
-            # Add truncation to handle long texts, limiting to 512 tokens
             truncated_text = text[:1000]  # Approximate truncation to stay under 512 tokens
             sentiment = models["sentiment_pipeline"](truncated_text)[0]
-            explanation = generate_gpt2_output(models["gpt2_tokenizer"], models["gpt2_model"], f"Explain why the sentiment is {sentiment['label']}: ", CONFIG['device'])
+            explanation = generate_gpt2_output(models["gpt2_tokenizer"], models["gpt2_model"], f"The text \"{truncated_text[:200]}\" has {sentiment['label']} sentiment because", CONFIG['device'])
             output = f"{sentiment['label'].capitalize()}. {explanation}"
         else:
-            prompt = f"{instruction}\n\nText: {text}\n\nOutput:"
+            # instruction already contains the few-shot prefix; append the actual text as the new case
+            prompt = f"{instruction}\nText: {text}\nOutput:"
             output = generate_gpt2_output(models["gpt2_tokenizer"], models["gpt2_model"], prompt, CONFIG['device'])
 
         batch_examples.append({

--- a/src/edu_dataset-generator.py
+++ b/src/edu_dataset-generator.py
@@ -37,19 +37,23 @@ def generate_dataset(num_examples: int, input_texts: List[str], models: Dict, de
 def generate_example(models: Dict, device: torch.device, instruction_type: str, instruction: str, input_text: str) -> Dict[str, Any]:
     max_attempts = 5
     for _ in range(max_attempts):
-        if instruction_type in ["concept_explanation", "provide_example", "analogy", "application"]:
-            output = generate_gpt2_output(models["gpt2_tokenizer"], models["gpt2_model"], f"{instruction}\n\nConcept: {input_text}\n\nExplanation:", device, max_length=100)
-        elif instruction_type in ["generate_question", "misconception"]:
-            output = generate_gpt2_output(models["gpt2_tokenizer"], models["gpt2_model"], f"{instruction}\n\nConcept: {input_text}\n\nOutput:", device, max_length=50)
-        elif instruction_type == "learning_path":
-            output = generate_t5_output(models["t5_tokenizer"], models["t5_model"], "generate learning path", f"Concept: {input_text}", device, max_length=150)
-        elif instruction_type == "quiz_generation":
-            output = generate_gpt2_output(models["gpt2_tokenizer"], models["gpt2_model"], f"{instruction}\n\nConcept: {input_text}\n\nQuiz question:", device, max_length=200)
+        if instruction_type == "learning_path":
+            # Use T5 for structured list output; prepend the few-shot prompt as context
+            output = generate_t5_output(models["t5_tokenizer"], models["t5_model"], "summarize", f"{instruction}\nConcept: {input_text}\nLearning path:", device, max_length=150)
+        elif instruction_type == "difficulty_assessment":
+            # Use T5 for structured output; summarize prefix is the closest real T5 task
+            output = generate_t5_output(models["t5_tokenizer"], models["t5_model"], "summarize", f"{instruction}\nConcept: {input_text}\nAssessment:", device, max_length=100)
         elif instruction_type == "concept_relation":
             related_concept = extract_keywords(input_text, n=1)[0]
-            output = generate_gpt2_output(models["gpt2_tokenizer"], models["gpt2_model"], f"{instruction}\n\nConcept 1: {input_text}\nConcept 2: {related_concept}\n\nRelation:", device, max_length=100)
-        elif instruction_type == "difficulty_assessment":
-            output = generate_t5_output(models["t5_tokenizer"], models["t5_model"], "assess difficulty", f"Concept: {input_text}", device, max_length=100)
+            prompt = f"{instruction}\nConcept 1: {input_text}\nConcept 2: {related_concept}\nRelation:"
+            output = generate_gpt2_output(models["gpt2_tokenizer"], models["gpt2_model"], prompt, device, max_length=100)
+        elif instruction_type == "quiz_generation":
+            prompt = f"{instruction}\nConcept: {input_text}\nQuestion:"
+            output = generate_gpt2_output(models["gpt2_tokenizer"], models["gpt2_model"], prompt, device, max_length=200)
+        else:
+            # concept_explanation, generate_question, provide_example, misconception, analogy, application
+            prompt = f"{instruction}\nConcept: {input_text}\nAnswer:"
+            output = generate_gpt2_output(models["gpt2_tokenizer"], models["gpt2_model"], prompt, device, max_length=100)
 
         if is_valid_output(instruction_type, output, input_text, models["sentence_model"]):
             return {

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,4 @@
+import argparse
 from data_loader import load_input_data
 from model_setup import setup_models
 from dataset_generator import generate_dataset
@@ -5,7 +6,26 @@ from validation import validate_dataset
 from utils import save_to_jsonl
 from config import CONFIG
 
+def parse_args():
+    parser = argparse.ArgumentParser(description="Generate Alpaca-format instruction datasets from documents.")
+    parser.add_argument("--input", type=str, help="Path to input folder containing .txt, .pdf, or .docx files")
+    parser.add_argument("--output", type=str, help="Path for the raw output JSONL file")
+    parser.add_argument("--validated-output", type=str, dest="validated_output", help="Path for the validated output JSONL file")
+    parser.add_argument("--num-examples", type=int, dest="num_examples", help="Number of examples to generate")
+    return parser.parse_args()
+
 def main():
+    args = parse_args()
+
+    if args.input:
+        CONFIG['input_folder'] = args.input
+    if args.output:
+        CONFIG['output_file'] = args.output
+    if args.validated_output:
+        CONFIG['validated_output_file'] = args.validated_output
+    if args.num_examples:
+        CONFIG['num_examples'] = args.num_examples
+
     print("Loading input data...")
     input_texts = load_input_data(CONFIG['input_folder'])
     if not input_texts:

--- a/src/main.py
+++ b/src/main.py
@@ -3,15 +3,23 @@ from data_loader import load_input_data
 from model_setup import setup_models
 from dataset_generator import generate_dataset
 from validation import validate_dataset
-from utils import save_to_jsonl
+from utils import save_to_jsonl, load_existing_jsonl, append_to_jsonl, deduplicate
 from config import CONFIG
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Generate Alpaca-format instruction datasets from documents.")
-    parser.add_argument("--input", type=str, help="Path to input folder containing .txt, .pdf, or .docx files")
+    parser.add_argument("--input", type=str, help="Path to input folder containing source documents")
     parser.add_argument("--output", type=str, help="Path for the raw output JSONL file")
     parser.add_argument("--validated-output", type=str, dest="validated_output", help="Path for the validated output JSONL file")
     parser.add_argument("--num-examples", type=int, dest="num_examples", help="Number of examples to generate")
+    parser.add_argument("--format", type=str, choices=["alpaca", "sharegpt"], default="alpaca", dest="fmt",
+                        help="Output format: 'alpaca' (default) or 'sharegpt'")
+    parser.add_argument("--resume", action="store_true",
+                        help="Resume a previous run — skip examples already written to the output file")
+    parser.add_argument("--no-dedup", action="store_true", dest="no_dedup",
+                        help="Disable semantic deduplication of generated examples")
+    parser.add_argument("--chunk-size", type=int, dest="chunk_size", help="Max characters per text chunk (default 1500)")
+    parser.add_argument("--chunk-overlap", type=int, dest="chunk_overlap", help="Overlap characters between chunks (default 200)")
     return parser.parse_args()
 
 def main():
@@ -25,7 +33,31 @@ def main():
         CONFIG['validated_output_file'] = args.validated_output
     if args.num_examples:
         CONFIG['num_examples'] = args.num_examples
+    if args.chunk_size:
+        CONFIG['chunk_size'] = args.chunk_size
+    if args.chunk_overlap:
+        CONFIG['chunk_overlap'] = args.chunk_overlap
 
+    output_fmt = args.fmt
+
+    # ------------------------------------------------------------------
+    # Resume: load already-generated examples and skip that many
+    # ------------------------------------------------------------------
+    existing = []
+    if args.resume:
+        existing = load_existing_jsonl(CONFIG['output_file'])
+        if existing:
+            print(f"Resuming: found {len(existing)} existing examples in {CONFIG['output_file']}")
+
+    remaining = CONFIG['num_examples'] - len(existing)
+    if remaining <= 0:
+        print(f"Already have {len(existing)} examples — target reached. Nothing to do.")
+        print("Run without --resume or increase --num-examples to generate more.")
+        return
+
+    # ------------------------------------------------------------------
+    # Load + generate
+    # ------------------------------------------------------------------
     print("Loading input data...")
     input_texts = load_input_data(CONFIG['input_folder'])
     if not input_texts:
@@ -35,20 +67,58 @@ def main():
     print("Setting up models...")
     models = setup_models()
 
-    print(f"Generating {CONFIG['num_examples']} examples...")
-    dataset = generate_dataset(input_texts, models)
+    print(f"Generating {remaining} new examples (target total: {CONFIG['num_examples']})...")
+    CONFIG['num_examples'] = remaining  # generate only what's still needed
+    new_examples = generate_dataset(input_texts, models)
 
-    print(f"Saving raw dataset to {CONFIG['output_file']}...")
-    save_to_jsonl(dataset, CONFIG['output_file'])
+    # ------------------------------------------------------------------
+    # Deduplication (across new + existing)
+    # ------------------------------------------------------------------
+    if not args.no_dedup:
+        print("Running semantic deduplication...")
+        all_examples = existing + new_examples
+        all_examples = deduplicate(
+            all_examples,
+            models["sentence_model"],
+            similarity_threshold=CONFIG.get('dedup_threshold', 0.95),
+        )
+        # Separate back into existing (already on disk) and new
+        existing_set = set(id(e) for e in existing)
+        new_examples = [e for e in all_examples if id(e) not in existing_set]
+    else:
+        all_examples = existing + new_examples
 
+    # ------------------------------------------------------------------
+    # Save raw output
+    # ------------------------------------------------------------------
+    if args.resume and existing:
+        # Append only the new examples; existing are already in the file
+        print(f"Appending {len(new_examples)} new examples to {CONFIG['output_file']}...")
+        for ex in new_examples:
+            append_to_jsonl(ex, CONFIG['output_file'], fmt=output_fmt)
+    else:
+        print(f"Saving {len(all_examples)} examples to {CONFIG['output_file']}...")
+        save_to_jsonl(all_examples, CONFIG['output_file'], fmt=output_fmt)
+
+    # ------------------------------------------------------------------
+    # Validate and save validated output
+    # ------------------------------------------------------------------
     print("Validating generated examples...")
-    validated_dataset = validate_dataset(dataset, models["sentence_model"])
+    validated = validate_dataset(new_examples, models["sentence_model"])
 
-    print(f"Saving validated dataset to {CONFIG['validated_output_file']}...")
-    save_to_jsonl(validated_dataset, CONFIG['validated_output_file'])
+    if args.resume and existing:
+        print(f"Appending {len(validated)} validated examples to {CONFIG['validated_output_file']}...")
+        for ex in validated:
+            append_to_jsonl(ex, CONFIG['validated_output_file'], fmt=output_fmt)
+    else:
+        print(f"Saving validated dataset to {CONFIG['validated_output_file']}...")
+        save_to_jsonl(validated, CONFIG['validated_output_file'], fmt=output_fmt)
 
-    print(f"Raw dataset with {len(dataset)} examples saved to '{CONFIG['output_file']}'")
-    print(f"Validated dataset with {len(validated_dataset)} examples saved to '{CONFIG['validated_output_file']}'")
+    total_raw = len(existing) + len(new_examples)
+    print(f"\nDone.")
+    print(f"  Raw examples:       {total_raw} (in '{CONFIG['output_file']}')")
+    print(f"  Validated examples: {len(validated)} new (in '{CONFIG['validated_output_file']}')")
+    print(f"  Output format:      {output_fmt}")
 
 if __name__ == "__main__":
     main()

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,6 @@
 import json
+import csv
+import re
 import torch
 import os
 from typing import List, Dict, Any
@@ -15,8 +17,11 @@ nltk.download('stopwords', quiet=True)
 # Import CONFIG if it's defined in a separate file
 from config import CONFIG
 
+# ---------------------------------------------------------------------------
+# File readers
+# ---------------------------------------------------------------------------
+
 def read_text_file(file_path: str) -> str:
-    """Read content from a text file."""
     try:
         with open(file_path, 'r', encoding='utf-8') as file:
             return file.read()
@@ -25,55 +30,181 @@ def read_text_file(file_path: str) -> str:
         return ""
 
 def read_pdf_file(file_path: str) -> str:
-    """Read content from a PDF file."""
     try:
         with open(file_path, 'rb') as file:
             reader = PyPDF2.PdfReader(file)
-            # Join pages with double newline to preserve paragraph breaks
             return '\n\n'.join([page.extract_text().strip() for page in reader.pages])
     except Exception as e:
         print(f"Error reading PDF file {file_path}: {e}")
         return ""
 
 def read_docx_file(file_path: str) -> str:
-    """Read content from a DOCX file."""
     try:
         doc = Document(file_path)
-        return ' '.join([paragraph.text for paragraph in doc.paragraphs])
+        return '\n\n'.join([p.text for p in doc.paragraphs if p.text.strip()])
     except Exception as e:
         print(f"Error reading DOCX file {file_path}: {e}")
         return ""
 
+def read_markdown_file(file_path: str) -> str:
+    """Read a Markdown file, stripping code fences and header markers."""
+    try:
+        with open(file_path, 'r', encoding='utf-8') as file:
+            text = file.read()
+        # Remove fenced code blocks entirely (they're not useful training prose)
+        text = re.sub(r'```[\s\S]*?```', '', text)
+        text = re.sub(r'`[^`]+`', '', text)
+        # Strip ATX heading markers (# ## ###) but keep the heading text
+        text = re.sub(r'^#{1,6}\s+', '', text, flags=re.MULTILINE)
+        return text
+    except IOError as e:
+        print(f"Error reading Markdown file {file_path}: {e}")
+        return ""
+
+def read_csv_file(file_path: str) -> str:
+    """Read a CSV file and return each row as a newline-separated prose chunk."""
+    try:
+        chunks = []
+        with open(file_path, 'r', encoding='utf-8', newline='') as file:
+            reader = csv.DictReader(file)
+            for row in reader:
+                # Represent each row as "field: value" pairs joined by semicolons
+                chunk = '; '.join(f"{k}: {v}" for k, v in row.items() if v and v.strip())
+                if chunk:
+                    chunks.append(chunk)
+        return '\n\n'.join(chunks)
+    except Exception as e:
+        print(f"Error reading CSV file {file_path}: {e}")
+        return ""
+
+def read_json_file(file_path: str) -> str:
+    """Read a JSON or JSONL file and return each record as a prose chunk."""
+    try:
+        chunks = []
+        with open(file_path, 'r', encoding='utf-8') as file:
+            content = file.read().strip()
+
+        # Try JSONL first (one JSON object per line)
+        if content.startswith('{'):
+            for line in content.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                    chunks.append(_flatten_json(obj))
+                except json.JSONDecodeError:
+                    pass
+        else:
+            # Regular JSON — could be a list or a single object
+            data = json.loads(content)
+            if isinstance(data, list):
+                for item in data:
+                    chunks.append(_flatten_json(item))
+            else:
+                chunks.append(_flatten_json(data))
+
+        return '\n\n'.join(chunks)
+    except Exception as e:
+        print(f"Error reading JSON file {file_path}: {e}")
+        return ""
+
+def _flatten_json(obj, prefix: str = '') -> str:
+    """Recursively flatten a JSON object into 'key: value' prose."""
+    parts = []
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            key = f"{prefix}.{k}" if prefix else k
+            parts.append(_flatten_json(v, key))
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            parts.append(_flatten_json(v, f"{prefix}[{i}]"))
+    else:
+        if prefix:
+            parts.append(f"{prefix}: {obj}")
+        else:
+            parts.append(str(obj))
+    return ' | '.join(p for p in parts if p)
+
 def read_file(file_path: str) -> str:
     """Read content from a file based on its extension."""
     _, ext = os.path.splitext(file_path.lower())
-    if ext == '.txt':
-        return read_text_file(file_path)
-    elif ext == '.pdf':
-        return read_pdf_file(file_path)
-    elif ext == '.docx':
-        return read_docx_file(file_path)
-    else:
+    readers = {
+        '.txt':  read_text_file,
+        '.pdf':  read_pdf_file,
+        '.docx': read_docx_file,
+        '.md':   read_markdown_file,
+        '.csv':  read_csv_file,
+        '.json': read_json_file,
+        '.jsonl': read_json_file,
+    }
+    if ext not in readers:
         raise ValueError(f"Unsupported file type: {ext}")
+    return readers[ext](file_path)
+
+# ---------------------------------------------------------------------------
+# Text chunking
+# ---------------------------------------------------------------------------
+
+def chunk_text(text: str, chunk_size: int = 1500, overlap: int = 200) -> List[str]:
+    """
+    Split text into overlapping chunks on sentence boundaries.
+
+    Instead of hard-truncating at max_chars, this produces multiple chunks
+    from long documents so no content is discarded.
+
+    Args:
+        text: Source text.
+        chunk_size: Target maximum characters per chunk.
+        overlap: Number of characters to repeat at the start of each new chunk
+                 to preserve context across chunk boundaries.
+
+    Returns:
+        List of cleaned text chunks, each within chunk_size characters.
+    """
+    # Normalise whitespace
+    paragraphs = [' '.join(p.split()) for p in text.split('\n\n') if p.strip()]
+    sentences = []
+    for para in paragraphs:
+        # Split on sentence-ending punctuation followed by whitespace
+        parts = re.split(r'(?<=[.!?])\s+', para)
+        sentences.extend(p for p in parts if p.strip())
+
+    chunks = []
+    current = []
+    current_len = 0
+
+    for sentence in sentences:
+        s_len = len(sentence)
+        if current_len + s_len > chunk_size and current:
+            chunk = ' '.join(current)
+            chunks.append(chunk)
+            # Roll back by overlap characters worth of sentences
+            rollback = []
+            rollback_len = 0
+            for sent in reversed(current):
+                if rollback_len + len(sent) > overlap:
+                    break
+                rollback.insert(0, sent)
+                rollback_len += len(sent)
+            current = rollback
+            current_len = rollback_len
+
+        current.append(sentence)
+        current_len += s_len
+
+    if current:
+        chunks.append(' '.join(current))
+
+    return [c for c in chunks if len(c) >= 50]
 
 def preprocess_text(text: str, max_chars: int = 2000) -> str:
     """
-    Preprocess the input text by:
-    1. Removing extra whitespace while preserving paragraph breaks
-    2. Truncating to prevent exceeding model token limits
-    
-    Args:
-        text: The input text to preprocess
-        max_chars: Maximum number of characters to keep (approximate token limit)
-    
-    Returns:
-        Preprocessed and potentially truncated text
+    Preprocess text for direct use as a single model input.
+    For bulk document loading, prefer chunk_text() instead.
     """
-    # Truncate the text if it's too long
     if len(text) > max_chars:
         text = text[:max_chars]
-    
-    # Split into paragraphs, clean each paragraph, then join with double newline
     paragraphs = [p.strip() for p in text.split('\n\n') if p.strip()]
     return '\n\n'.join([' '.join(p.split()) for p in paragraphs])
 
@@ -160,9 +291,105 @@ def is_valid_output(
 
     return True
 
-def save_to_jsonl(data: List[Dict[str, Any]], output_file: str):
-    """Save data to a JSONL file."""
+# ---------------------------------------------------------------------------
+# Output format conversion
+# ---------------------------------------------------------------------------
+
+def to_sharegpt(example: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert an Alpaca-format example to ShareGPT multi-turn format."""
+    human_turn = example["instruction"]
+    if example.get("input", "").strip():
+        human_turn = f"{example['instruction']}\n\n{example['input']}"
+    return {
+        "conversations": [
+            {"from": "human", "value": human_turn},
+            {"from": "gpt",   "value": example["output"]},
+        ]
+    }
+
+def save_to_jsonl(data: List[Dict[str, Any]], output_file: str, fmt: str = "alpaca"):
+    """
+    Save data to a JSONL file.
+
+    Args:
+        data: List of Alpaca-format examples.
+        output_file: Destination file path.
+        fmt: 'alpaca' (default) or 'sharegpt'.
+    """
+    os.makedirs(os.path.dirname(os.path.abspath(output_file)), exist_ok=True)
+    converter = to_sharegpt if fmt == "sharegpt" else (lambda x: x)
     with open(output_file, 'w', encoding='utf-8') as f:
         for item in data:
-            json.dump(item, f, ensure_ascii=False)
+            json.dump(converter(item), f, ensure_ascii=False)
             f.write('\n')
+
+def load_existing_jsonl(file_path: str) -> List[Dict[str, Any]]:
+    """Load existing JSONL records for resume support."""
+    if not os.path.exists(file_path):
+        return []
+    records = []
+    with open(file_path, 'r', encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+    return records
+
+def append_to_jsonl(item: Dict[str, Any], output_file: str, fmt: str = "alpaca"):
+    """Append a single example to a JSONL file (used for streaming/resume)."""
+    os.makedirs(os.path.dirname(os.path.abspath(output_file)), exist_ok=True)
+    converter = to_sharegpt if fmt == "sharegpt" else (lambda x: x)
+    with open(output_file, 'a', encoding='utf-8') as f:
+        json.dump(converter(item), f, ensure_ascii=False)
+        f.write('\n')
+
+# ---------------------------------------------------------------------------
+# Deduplication
+# ---------------------------------------------------------------------------
+
+def deduplicate(
+    examples: List[Dict[str, Any]],
+    sentence_model: SentenceTransformer,
+    similarity_threshold: float = 0.95,
+) -> List[Dict[str, Any]]:
+    """
+    Remove near-duplicate examples using output embedding cosine similarity.
+
+    An example is dropped if its output is more than `similarity_threshold`
+    similar to any already-kept example's output.
+
+    Args:
+        examples: List of Alpaca-format dicts.
+        sentence_model: SentenceTransformer for encoding outputs.
+        similarity_threshold: Cosine similarity above which an example is a duplicate.
+
+    Returns:
+        Deduplicated list.
+    """
+    if not examples:
+        return []
+
+    outputs = [ex["output"] for ex in examples]
+    embeddings = sentence_model.encode(outputs, convert_to_tensor=True, show_progress_bar=True)
+
+    kept_indices = []
+    kept_embeddings = []
+
+    for i, emb in enumerate(embeddings):
+        if not kept_embeddings:
+            kept_indices.append(i)
+            kept_embeddings.append(emb)
+            continue
+
+        kept_tensor = torch.stack(kept_embeddings)
+        sims = torch.cosine_similarity(emb.unsqueeze(0), kept_tensor, dim=1)
+        if sims.max().item() < similarity_threshold:
+            kept_indices.append(i)
+            kept_embeddings.append(emb)
+
+    removed = len(examples) - len(kept_indices)
+    print(f"Deduplication: removed {removed} near-duplicates, kept {len(kept_indices)}")
+    return [examples[i] for i in kept_indices]


### PR DESCRIPTION
- Fix typo in config.py: min_learning_path_stepspath_steps → min_learning_path_steps (was causing KeyError at runtime)
- Fix sentiment explanation prompt to include the source text so GPT-2 can actually explain why that specific text has that sentiment
- Add --input, --output, --validated-output, --num-examples CLI arguments to main.py so paths no longer need to be hardcoded in config.py
- Add one-shot examples to all 6 main generator prompts and all 10 edu generator prompts in config.py, giving models a concrete input→output pattern to follow
- Consolidate edu generator generate_example into a cleaner if/else structure; replace invalid T5 prefixes (generate learning path, assess difficulty) with the summarize prefix which T5 was actually trained on

https://claude.ai/code/session_01YB9ijvB8aQW9BMSYPcoPoU